### PR TITLE
Initial repo creation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# wg-funding-impact
+# Funding Impact Measurement Working Group
 The CHAOSS Working Group on OSS Funding Impacts aims to develop frameworks, metrics, and methodologies for measuring and understanding the impacts of funding on open source software development. The group will bring together researchers, developers, funders, and policymakers to create practical tools and approaches for evaluating funding outcomes.
 
 ## Table of Contents

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
 # wg-funding-impact
 The CHAOSS Working Group on OSS Funding Impacts aims to develop frameworks, metrics, and methodologies for measuring and understanding the impacts of funding on open source software development. The group will bring together researchers, developers, funders, and policymakers to create practical tools and approaches for evaluating funding outcomes.
+
+## Table of Contents
+
+- [Context](#context)
+- [Objectives](#objectives)
+- [Working Group Chairs][#chairs]
+- [Participate](#participate)
+- [Activities](#activities)
+- [License](#license)
+
+## Context
+The open source community increasingly recognizes funding as critical for project sustainability, yet measuring funding impacts remains challenging. Does it make a meaningful difference in project security and sustainability? Does it contribute to healthier communities? Does it foster long-term resilience and technological diversity? This working group will bring together diverse stakeholders to develop standardized approaches for evaluating how funding influences and supports open source projects and developer communities.
+
+## Objectives
+- Develop standardized frameworks and metrics for measuring economic, social, and technological impacts of open source funding
+- Create guidelines and tools to help funders and OSS projects evaluate funding outcomes
+- Document and share best practices across different project types and funding models
+- Build an evidence base of effective funding approaches for different contexts or needs
+- Foster collaboration between researchers, practitioners, and funders
+- Contribute to broader discussions about sustaining critical open source infrastructure
+
+## Chairs 
+
+- [Cailean Osborne](https://github.com/ccosborne/)
+- [Paul Sharratt](https://github.com/psharratt)
+- [Dawn Foster](https://github.com/geekygirldawn)
+
+## Participate
+
+- We meet every other week over Zoom, and meeting details can by found on the [CHAOSS Calendar](https://chaoss.community/chaoss-calendar/)
+- [Agenda/Meeting-Minutes]() ADD LINK
+- Join us in the #wg-funding-impact channel within the CHAOSS Slack Workspace.
+
+Contribution guidelines can be found in the [CHAOSS Community CONTRIBUTING.MD](https://github.com/chaoss/community/blob/main/CONTRIBUTING.md).
+
+We follow the [CHAOSS Code of Conduct](https://github.com/chaoss/governance/blob/master/code-of-conduct.md).
+
+## Activities
+- Develop and refine metrics for measuring funding impacts 
+- Create documentation and guidelines for measuring funding impacts
+- Develop tools for data collection and analysis (e.g. scripts, Jupyter notebooks) 
+- Build relationships between funders, researchers, and communities
+- Maintain list (database) of relevant resources (e.g. papers, reports, talks)
+- Review case studies to identify patterns and lessons learned
+- Host discussions with invited speakers from funded projects and funders
+- Contribute findings to broader CHAOSS community
+
+## License
+
+MIT License - see [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The CHAOSS Working Group on OSS Funding Impacts aims to develop frameworks, metr
 
 - [Context](#context)
 - [Objectives](#objectives)
-- [Working Group Chairs][#chairs]
+- [Working Group Chairs](#chairs)
 - [Participate](#participate)
 - [Activities](#activities)
 - [License](#license)

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The open source community increasingly recognizes funding as critical for projec
 ## Participate
 
 - We meet every other week over Zoom, and meeting details can by found on the [CHAOSS Calendar](https://chaoss.community/chaoss-calendar/)
-- [Agenda/Meeting-Minutes]() ADD LINK
-- Join us in the #wg-funding-impact channel within the CHAOSS Slack Workspace.
+- [Agenda/Meeting-Minutes](https://docs.google.com/document/d/1PMDWc6xMe0fNE7shxTK5_HE_ykRBG5w55_Zx5hvzsEY/edit?pli=1&tab=t.kta9wxvh7pj8#heading=h.oznzkn3t2ext)
+- Join us in the #wg-funding-impact channel within the CHAOSS Slack Workspace ([invite link](https://join.slack.com/t/chaoss-workspace/shared_invite/zt-r65szij9-QajX59hkZUct82b0uACA6g) to join CHAOSS Slack).
 
 Contribution guidelines can be found in the [CHAOSS Community CONTRIBUTING.MD](https://github.com/chaoss/community/blob/main/CONTRIBUTING.md).
 


### PR DESCRIPTION
Added details about the WG from Cailean's doc and added basic information that we put in the CHAOSS WG repos.

After reviewing the Doodle poll and other CHAOSS meetings, we plan to start it on Wed, Feb 12 with it being every other week at 9am US Central Time.

Putting this out here now as a start, but we're not in any rush. Since we plan to announce it at CHAOSScon, we should probably try to  merge this next week to avoid running into people's FOSDEM travel.

Before we merge it, we still need to:
* Add it to the CHAOSS Calendar and meeting notes doc (@ElizabethN to do this)
* Create the Slack Channel (@geekygirldawn to do this)

@ccosborne and @psharratt - I've added you both to this repo with write access, so you'll need to accept that invite, and then I'd love to have your review on this PR :)